### PR TITLE
hostname does not exists on aws_route53_record

### DIFF
--- a/dns/aws/main.tf
+++ b/dns/aws/main.tf
@@ -57,5 +57,5 @@ resource "aws_route53_record" "wildcard" {
 }
 
 output "domains" {
-  value = ["${aws_route53_record.hosts.*.hostname}"]
+  value = ["${aws_route53_record.hosts.*.name}"]
 }


### PR DESCRIPTION
the aws dns provider was not working for me and error'd with:
`* module.dns.output.domains: Resource 'aws_route53_record.hosts' does not have attribute 'hostname' for variable 'aws_route53_record.hosts.*.hostname'`

i've checked the aws providers code and compared it to cloudflare and turns out the aws provider does not set hostname, but rather name.